### PR TITLE
ビルドプロセスを改善

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,10 @@ jobs:
         run: pnpm install
       
       - name: Build WASM module
-        run: pnpm --filter @boid-wasm-sim/wasm build
+        run: |
+          pnpm --filter @boid-wasm-sim/wasm build
+          # wasm_exec.jsをwasmディレクトリにコピー（Goのランタイムから）
+          cp "$(go env GOROOT)/misc/wasm/wasm_exec.js" wasm/
       
       - name: Build web packages
         run: |
@@ -52,7 +55,7 @@ jobs:
       - name: Build web application for GitHub Pages
         run: |
           cd web/main
-          pnpm build
+          VITE_BASE_PATH=/boid-wasm-sim/ pnpm build
         env:
           # GitHub Pagesのベースパスを設定（リポジトリ名に応じて調整）
           VITE_BASE_PATH: /boid-wasm-sim/
@@ -61,9 +64,12 @@ jobs:
         run: |
           echo "Build output contents:"
           ls -la web/main/dist/
-          echo "WASM files:"
+          echo "WASM files in dist:"
           ls -la web/main/dist/*.wasm || echo "No WASM files found in dist"
+          echo "WASM files in public:"
           ls -la web/main/public/*.wasm || echo "No WASM files found in public"
+          echo "wasm_exec.js:"
+          ls -la web/main/dist/wasm_exec.js || echo "No wasm_exec.js found in dist"
       
       - name: Setup GitHub Pages
         uses: actions/configure-pages@v5

--- a/web/main/vite.config.ts
+++ b/web/main/vite.config.ts
@@ -11,18 +11,24 @@ export default defineConfig({
       name: "copy-wasm",
       buildStart() {
         // WASMファイルをpublicディレクトリにコピー
-        const wasmSrc = join(__dirname, "../../wasm/build/boid.wasm")
-        const wasmDest = join(__dirname, "public/build")
+        const wasmSrc = join(__dirname, "../../wasm/boid.wasm")
+        const wasmExecSrc = join(__dirname, "../../wasm/wasm_exec.js")
+        const publicDir = join(__dirname, "public")
 
-        if (!existsSync(wasmDest)) {
-          mkdirSync(wasmDest, { recursive: true })
-        }
-
+        // WASMファイルをコピー
         if (existsSync(wasmSrc)) {
-          copyFileSync(wasmSrc, join(wasmDest, "boid.wasm"))
-          console.log("✓ Copied WASM file to public/build/")
+          copyFileSync(wasmSrc, join(publicDir, "boid.wasm"))
+          console.log("✓ Copied WASM file to public/")
         } else {
           console.warn("⚠ WASM file not found. Run 'pnpm wasm:build' first.")
+        }
+
+        // wasm_exec.jsをコピー
+        if (existsSync(wasmExecSrc)) {
+          copyFileSync(wasmExecSrc, join(publicDir, "wasm_exec.js"))
+          console.log("✓ Copied wasm_exec.js to public/")
+        } else {
+          console.warn("⚠ wasm_exec.js not found.")
         }
       },
     },


### PR DESCRIPTION
This pull request updates the build and deployment process for a WASM-based project, focusing on improved handling of WASM files and the `wasm_exec.js` runtime. The changes ensure that necessary files are correctly copied and available during the build and deployment stages, and they refine the logging for better visibility into the build outputs.

### Workflow updates for WASM handling:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L45-R48): Updated the build process to copy `wasm_exec.js` from the Go runtime to the `wasm` directory after building the WASM module.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L55-R58): Modified the web application build step to set the `VITE_BASE_PATH` environment variable explicitly for GitHub Pages deployment.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L64-R72): Enhanced logging to include checks for `wasm_exec.js` and additional WASM file locations in both `dist` and `public` directories.

### Vite configuration improvements:
* [`web/main/vite.config.ts`](diffhunk://#diff-c91f75d07cdecd95a9a72db614242029e040fc80604f3cd9d743d6cdeb806fadL14-R32): Updated the custom Vite plugin to copy both `boid.wasm` and `wasm_exec.js` into the `public` directory, ensuring they are available for the web application. Added warnings if either file is missing.