### PR TITLE
wasm_exec.jsのコピー手順を修正し、WASMモジュールのビルドを適切に実行

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,11 +41,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       
-      - name: Build WASM module
+      - name: Copy wasm_exec.js
         run: |
-          pnpm --filter @boid-wasm-sim/wasm build
-          # wasm_exec.jsをwasmディレクトリにコピー（Goのランタイムから）
+          # wasm_exec.jsを先にコピー
+          cp "$(go env GOROOT)/misc/wasm/wasm_exec.js" web/main/public/
           cp "$(go env GOROOT)/misc/wasm/wasm_exec.js" wasm/
+      
+      - name: Build WASM module
+        run: pnpm --filter @boid-wasm-sim/wasm build
       
       - name: Build web packages
         run: |


### PR DESCRIPTION
This pull request includes a small update to the `.github/workflows/deploy.yml` file to adjust the sequence of steps in the deployment workflow. The change separates the copying of `wasm_exec.js` into its own step and ensures it occurs before building the WASM module.

Key change:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L44-R52): Added a dedicated step to copy `wasm_exec.js` from the Go runtime to the appropriate directories (`web/main/public/` and `wasm/`) before building the WASM module. This ensures the file is available for the build process.