### PR TITLE
wasm_exec.jsとboid.wasmのパスを相対パスに変更

### DIFF
--- a/web/hooks/src/useBoidWasm.ts
+++ b/web/hooks/src/useBoidWasm.ts
@@ -42,8 +42,8 @@ export function useBoidWasm() {
         setIsLoading(true)
         setError(null)
 
-        // Go WASMランタイムをロード
-        const wasmExecResponse = await fetch("/wasm_exec.js")
+        // Go WASMランタイムをロード（相対パスを使用）
+        const wasmExecResponse = await fetch("./wasm_exec.js")
         const wasmExecText = await wasmExecResponse.text()
 
         // wasm_exec.jsを実行してGoオブジェクトを作成
@@ -51,9 +51,9 @@ export function useBoidWasm() {
         script.textContent = wasmExecText
         document.head.appendChild(script)
 
-        // GoのWASMインスタンスを作成
+        // GoのWASMインスタンスを作成（相対パスを使用）
         const go = new window.Go()
-        const wasmResponse = await fetch("/boid.wasm")
+        const wasmResponse = await fetch("./boid.wasm")
         const wasmBytes = await wasmResponse.arrayBuffer()
         const wasmModule = await WebAssembly.instantiate(wasmBytes, go.importObject)
 


### PR DESCRIPTION
## BG

Github Pagesでhttps://logta.github.io/wasm_exec.jsで取得しようとしている

ただ、https://logta.github.io/boid-wasm-sim/wasm_exec.jsで取得する必要がある
Pathが正しくなるよう修正する

## What

このプルリクエストでは、`useBoidWasm`フックを更新し、WebAssemblyリソースの読み込みに相対パスを使用するようにしました。これにより、絶対パスが機能しない可能性がある環境での互換性が確保されます。

主な変更：
* [`web/hooks/src/useBoidWasm.ts`](diffhunk://#diff-e6614d0965a560c6f174060500d09c589ab003ca58be8dfa5826d3ffbe0e2edeL45-R56): `wasm_exec.js`と`boid.wasm`のフェッチURLを、絶対パス（`"/wasm_exec.js"`と`"/boid.wasm"`）から相対パス（`"./wasm_exec.js"`と`"./boid.wasm"`）に変更しました。これにより、デプロイメント環境での柔軟性が向上します。